### PR TITLE
Orlando: combined entry migration format - draft one

### DIFF
--- a/cwrc_migration_batch.drush.inc
+++ b/cwrc_migration_batch.drush.inc
@@ -1902,7 +1902,7 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
     // build combined doc with both biography and writing orlando documents
     // <ORLANDO><BIOGRAPHY/><WRITING></ORLANDO>
     $tmp_doctype = "<!DOCTYPE ORLANDO [ <!ENTITY % character_entities SYSTEM 'http://cwrc.ca/schemas/character_entities.dtd'> %character_entities; ]>\n";
-    $legacy_content =
+    $legacy_combined =
         "<?xml version='1.0' encoding='UTF-8'?>\n"
         . "<?xml-model href='https://cwrc.ca/schemas/orlando_entry.rng' type='application/xml' schematypens='http://relaxng.org/ns/structure/1.0'?>\n"
         . "<?xml-stylesheet type='text/css' href='https://cwrc.ca/templates/css/orlando.css'?>\n"
@@ -1920,7 +1920,7 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
     // build the version 2.0 of the biography / writing document
     // UTF-8 + Legacy Dates + remove DOCTYPE
     $to_v2_xslt_proc->setSourceFromXdmValue(
-      $saxonProc->parseXmlFromString($legacy_content)
+      $saxonProc->parseXmlFromString($legacy_combined)
     );
     //$bio_writ_to_v2_xslt_proc->setSourceFromXdmValue($content_dom);
     $content_v2_xml = $to_v2_xslt_proc->transformToString();

--- a/cwrc_migration_batch.drush.inc
+++ b/cwrc_migration_batch.drush.inc
@@ -71,6 +71,7 @@ function cwrc_migration_batch_drush_command() {
     'bootstrap' => DRUSH_BOOTSTRAP_MAX,
   );
 
+  # 2019-12-19: events only? 
   $items['cwrc_migration_batch_ingest_orlando_biography_writing'] = array(
     'description' => 'Ingest Orlando Biography/Writing/event objects into CWRC',
     'options' => array(
@@ -90,6 +91,28 @@ function cwrc_migration_batch_drush_command() {
     ),
     'bootstrap' => DRUSH_BOOTSTRAP_MAX,
   );
+
+  # 2019-12-19: combine bio/writ 
+  $items['cwrc_migration_batch_ingest_orlando_combine_biography_writing'] = array(
+    'description' => 'Ingest Orlando Biography/Writing objects into CWRC',
+    'options' => array(
+      'legacy_dir' => 'path to directory of legacy source material',
+      'xslt_to_v2' => 'convert legacy bio/writ docs to version 2 (convert dates, utf-8)',
+      'xslt_to_mods' => 'path to XSLT to convert biography/writing/event to mods',
+      'xslt_mods_to_dc' => 'path to XSLT to convert mods to DC',
+      'collection_pid_pub_c' => 'add object to the given collection if PUC-C workflow',
+      'collection_pid_non_pub_c' => 'add object to the given collection if no PUB-C workflow',
+      'cModel_pid' => 'cModel pid assigments',
+      'schema_object' => 'schema object pid assigments',
+      'XACML_policy' => 'path to the default XACML policy',
+      'namespace' => 'pid namespace',
+    ),
+    'examples' => array(
+      'drush -u 1 cwrc_migration_batch_ingest_orlando_combine_biography_writing ',
+    ),
+    'bootstrap' => DRUSH_BOOTSTRAP_MAX,
+  );
+
 
  
   $items['cwrc_migration_batch_ingest_orlando_entities'] = array(
@@ -1656,6 +1679,417 @@ function drush_cwrc_migration_batch_ingest_orlando_biography_writing ()
         );
       CWRCWorkflowAPI::updateDatastream($workflow, $object);
 
+      //update URI's refences in entities
+      if ($object['CWRC'])
+      {
+        cwrc_migration_batch_add_entity_refs($object, "CWRC");
+      }
+    }
+    catch (Exception $e) {
+      $file_error_count++;
+      drush_print("pid=$pid title=\"$title\" was not added.");
+      drush_print($e->getMessage());
+    }
+
+  }
+  drush_print('Migration Complete');
+  drush_print('Number of files migrated: ' . $file_count);
+  drush_print('Number of errors: ' . $file_error_count);
+
+}
+
+/** 
+ * CWRC migration batch - combine biography / writing Orlando version 3 - 2019-12-19
+ * assumes MODS and DC generated on the fly 
+ * workflow is pulled from the legacy Orlando format stored in subdir
+ * the separate biography and writing docs for a person are
+ * linked via MODS entity reference
+ *
+ */
+function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing () 
+{
+  module_load_include('inc', 'islandora_cwrc_writer', 'includes/utilities');
+
+  module_load_include('inc', 'islandora_workflow_rest', 'includes/cwrc_workflow');
+  module_load_include('inc', 'islandora_workflow_rest', 'includes/basic_enum');
+  module_load_include('inc', 'islandora_workflow_rest', 'includes/workflow_item');
+  module_load_include('inc', 'islandora_workflow_rest', 'includes/utilities');
+
+
+  drush_print("Orlando Biography / Writing / Event migration batch version 2.0");
+
+  // path to the input document files 
+  $legacy_dir = drush_get_option('legacy_dir','/tmp/orlando/bio_writ');
+
+  // 
+  $ext_home = drupal_get_path('module', 'cwrc_migration_batch') . '/';
+  $xslt_to_v2 = drush_get_option(
+    'xslt_to_v2'
+    , $ext_home . 'transforms/orlando_legacy_to_v2_bio_writing.xsl'
+  );
+  $xslt_to_mods = drush_get_option(
+    'xslt_to_mods'
+    , $ext_home . 'transforms/orlando_combined_bio_writing_TO_mods.xsl'
+  );
+  $xslt_mods_to_dc = drush_get_option(
+    'xslt_mods_to_dc'
+    , libraries_get_path('islandora_cwrc_xslt_library') . '/xslt/mods_to_dc.xsl'
+  );
+  
+  $collection_pid_pub_c = drush_get_option(
+    'collection_pid_pub_c'
+    , 'cwrc:fc271c04-7fd1-46b4-9462-339dbe917c46'
+  );
+  $collection_pid_non_pub_c = drush_get_option(
+    'collection_pid_non_pub_c'
+    , 'cwrc:bf8ba2b7-dbed-440b-9000-88860be1bcc9'
+  );
+  $cModel_pid = drush_get_option(
+    'cModel_pid' , 'cwrc:documentCModel'
+  );
+  $schemaObject = drush_get_option(
+    'schema_object', 'cwrc:biographySchema'
+  );
+  $policy = drush_get_option(
+    'XACML_policy', $ext_home . 'xml/orlando_default_XACML_Policy_Stream.xml'
+  );
+  $namespace = drush_get_option(
+    'namespace', 'orlando'
+  );
+
+
+  // Include modules.
+  $connection = null;
+  migration_init($connection);
+
+  // Display the user.
+  drush_print("User: " . $connection->connection->username);
+
+  
+  // setup XSL 
+  // http://www.saxonica.com/saxon-c/index.xml#debug
+  //xslt_setup($xslt_bio_writ_to_v2, $bio_writ_to_v2_xslt_proc);
+  //xslt_setup($xslt_bio_writ_to_mods, $bio_writ_to_mods_xslt_proc);
+  //xslt_setup($xslt_mods_to_dc, $mods_to_dc_xslt_proc);
+  
+  $saxonProc = new Saxon\SaxonProcessor();
+  drush_print("XSLT Version: " . $saxonProc->version());
+  
+  $to_v2_xslt_proc = $saxonProc->newXsltProcessor();
+  $to_mods_xslt_proc = $saxonProc->newXsltProcessor();
+  $mods_to_dc_xslt_proc = $saxonProc->newXsltProcessor();
+
+  $to_v2_xslt_proc->compileFromFile($xslt_to_v2);
+  $to_mods_xslt_proc->compileFromFile($xslt_to_mods);
+  $mods_to_dc_xslt_proc->compileFromFile($xslt_mods_to_dc);
+
+
+  // xpath to determine if PUB-C Orlando document - Biography/Writing/Event
+  $xpathStrPub = "/*/ORLANDOHEADER/REVISIONDESC/RESPONSIBILITY[@WORKSTATUS='PUB' and @WORKVALUE='C']";
+  //$xpathStrBio = "/BIOGRAPHY";
+  //$xpathStrWriting = "/WRITING";
+
+  // Set source directory for the legacy Orlando content
+  // Open the source direcotry and iterate through every file in the 
+  // directory - one file maps to one Fedora 
+  drush_print("Input legacy dir: " . $legacy_dir);
+  $legacy_bio = $legacy_dir . "/biography/";
+  $legacy_writ = $legacy_dir . "/writing/";
+  $legacy_sccs = $legacy_dir . "/sccs/";
+
+  // build hash map of author ids with bio/writing doc attached
+  // entries = array(
+  //                "austja" => array(
+  //                        "bio_xml" => ""
+  //                        "writing_xml" => ""
+  //                        "bio_sccs" => ""
+  //                        "writing_sccs" => ""
+  //                        )
+  //                )
+  $entries = array();
+  build_hash_map($entries, $legacy_writ, "writ_xml", "writ_sccs");
+  build_hash_map($entries, $legacy_bio, "bio_xml", "bio_sccs");
+
+  // Counter for the number of files to migrate.
+  $file_count = 0; 
+  $file_error_count = 0;
+  foreach ($entries as $key => $entry) {
+
+    $pid = null;
+
+    //PHP Fatal error:  Maximum execution time of 300 seconds exceeded
+    // no effect when PHP is running in safe mode
+    // http://php.net/manual/en/function.set-time-limit.php
+    set_time_limit(5);
+
+    drush_print("Entry: " . $key);
+
+    // generate an id for the object
+    $pid = $connection->repository->getnextIdentifier($namespace, TRUE);
+
+    // Strip out the .xml from the file name and store in the variable.
+    //preg_match('/[a-z0-9-_]*/', $file_name, $object_name);
+    // Strip out file name to get type -b(biography) or -w (writable).
+    //preg_match('/-[a-z]?/', $file_name, $object_type);
+    //$object_name = $object_name[0];
+    //$object_type = $object_type[0];
+    //$pid = "cwrc:$object_name";
+
+    // If the object already exists then continue to next file.
+    if (islandora_object_load($pid)) {
+      drush_print("object $pid - $key is already in fedora");
+      continue;
+    }
+
+
+    // get legacy files
+    $legacy_writing_content = null;
+    if (isset($entry['writ_xml'])) {
+        $legacy_writing_content = file_get_contents($legacy_dir."/writing/".$entry['writ_xml']);
+    }
+    $legacy_biography_content = null;
+    if (isset($entry['bio_xml'])) {
+        $legacy_biography_content = file_get_contents($legacy_dir."/biography/".$entry['bio_xml']);
+    }
+
+    // build combined doc with both biography and writing orlando documents
+    // <ORLANDO><BIOGRAPHY/><WRITING></ORLANDO>
+    $tmp_doctype = "<!DOCTYPE ORLANDO [ <!ENTITY % character_entities SYSTEM 'http://cwrc.ca/schemas/character_entities.dtd'> %character_entities; ]>\n";
+    $legacy_content =
+        "<?xml version='1.0' encoding='UTF-8'?>\n"
+        . "<?xml-model href='https://cwrc.ca/schemas/orlando_entry.rng' type='application/xml' schematypens='http://relaxng.org/ns/structure/1.0'?>\n"
+        . "<?xml-stylesheet type='text/css' href='https://cwrc.ca/templates/css/orlando.css'?>\n"
+        . $tmp_doctype
+        . "<ORLANDO ID='".$key."'>\n"
+        . ((isset($entry['bio_xml'])) ? preg_replace("/^.*(<BIOGRAPHY.+$)/s",'$1', $legacy_biography_content) : "")
+        . ((isset($entry['writ_xml'])) ? preg_replace('/^.*(<WRITING.+$)/s','$1', $legacy_writing_content) : "")
+        . "</ORLANDO>"
+        ;
+
+        
+    //drush_print($legacy_content);
+
+
+    // build the version 2.0 of the biography / writing document
+    // UTF-8 + remove DOCTYPE
+    $to_v2_xslt_proc->setSourceFromXdmValue(
+      $saxonProc->parseXmlFromString($legacy_content)
+    );
+    //$bio_writ_to_v2_xslt_proc->setSourceFromXdmValue($content_dom);
+    $content_v2_xml = $to_v2_xslt_proc->transformToString();
+    $content_v2_xml = str_replace($tmp_doctype , "" , $content_v2_xml);
+
+    //drush_print($content_v2_xml);
+
+    // Build MODS XML.
+    $to_mods_xslt_proc->setParameter(
+      "param_original_id", $saxonProc->createAtomicValue($key) 
+      );
+    if (isset($entry['bio_xml'])) {
+        $to_mods_xslt_proc->setParameter(
+            "param_original_bio_filename", $saxonProc->createAtomicValue($entry['bio_xml']) 
+            );
+    }
+    if (isset($entry['writ_xml'])) {
+        $to_mods_xslt_proc->setParameter(
+            "param_original_writ_filename", $saxonProc->createAtomicValue($entry['writ_xml']) 
+            );
+    }
+    $to_mods_xslt_proc->setSourceFromXdmValue(
+      $saxonProc->parseXmlFromString($content_v2_xml)
+      );
+    $mods_xml = $to_mods_xslt_proc->transformToString();
+
+    //print ("zzzzzzzzzzzzzzzzzzzz " . $mods_xml);
+
+
+    // build the DC content
+    // Convert MODS to DC.
+    // Transform to DC xml.
+    // Apply the stylesheet.
+    //$mods_to_dc_xslt_proc->setParameter( "", "PID_PARAM", $pid );
+    //$dc_xml = $mods_to_dc_xslt_proc->transformToString($mods_dom);
+    $mods_to_dc_xslt_proc->setSourceFromXdmValue(
+      $saxonProc->parseXmlFromString($mods_xml)
+    );
+    $dc_xml = $mods_to_dc_xslt_proc->transformToString();
+
+    //print ("zzzzzzzzzzzzzzzzzzzz " . $dc_xml);
+
+    // set object title
+    $title = get_dcTitle_from_dc($dc_xml);
+
+    //print("dc:title extracted - \"$title\" \n");
+
+    // TODO: update 2019-12-20 based on new schema
+    // determine collection PUB-C versus non-PUB-C based on workflow
+    $content_dom = new DOMDocument();
+    $content_dom->loadXML($content_v2_xml);
+    $xpathObj = new DOMXpath($content_dom); 
+    $pubCRes = $xpathObj->query($xpathStrPub);
+    $collection_pid = $collection_pid_non_pub_c;
+    if (!is_null($pubCRes) and $pubCRes->length>0)
+    {
+      $collection_pid = $collection_pid_pub_c;
+      drush_print("pub-c");
+    } 
+
+    //determine the schema for the object
+    //$schema_obj = null;
+    //$tmpBioSchema = $xpathObj->query($xpathStrBio);
+    //if (!is_null($tmpBioSchema))
+    //{
+      //$schema_obj = islandora_object_load($bioSchemaObject);
+    //}
+    //$tmpWritingSchema = $xpathObj->query($xpathStrWriting);
+    //if (!is_null($tmpWritingSchema))
+    //{
+      //$schema_obj = islandora_object_load($writingSchemaObject);
+    //}
+    $schema_obj = islandora_object_load($schemaObject);
+
+
+    // prepare a new Fedora object.
+    $object
+      = islandora_prepare_new_object(
+        $pid 
+        , $title
+        , array()
+        , array($cModel_pid)
+        , array(
+          array(
+            'relationship' => 'isMemberOfCollection'
+            , 'pid' => "$collection_pid"
+          )
+        )
+      );
+
+    // common label root
+    //$content_datastream_label = preg_replace('/(\.sgm)$/','.xml', $file_name); 
+    $content_datastream_label = $key;
+
+    // create LEGACY_WRITING XML datastream from Doc Archive contents <=2019
+    if (isset($entry['writ_xml'])) {
+        $cwrc_ds = $object->constructDatastream('LEGACY_WRITING_XML', 'M');
+        $cwrc_ds->label = $content_datastream_label."-w.xml";
+        $cwrc_ds->mimeType = 'text/xml';
+        $cwrc_ds->setContentFromString($legacy_writing_content);
+        $object->ingestDatastream($cwrc_ds);
+    }
+
+    // create LEGACY_WRITING SCCS version datastream from Doc Archive contents <=2019
+    if (isset($entry['writ_sccs'])) {
+        //$legacy_writing_sccs = file_get_contents($legacy_dir."/sccs/".$entry['writ_sccs']);
+        $legacy_writing_sccs = $legacy_dir."/sccs/".$entry['writ_sccs'];
+        $cwrc_ds = $object->constructDatastream('LEGACY_WRITING_SCCS', 'M');
+        $cwrc_ds->label = "s.".$content_datastream_label."-w.sgm";
+        $cwrc_ds->mimeType = 'application/octet-stream';
+        $cwrc_ds->setContentFromFile($legacy_writing_sccs, FALSE);
+        //$cwrc_ds->setContentFromString($legacy_writing_sccs);
+        $object->ingestDatastream($cwrc_ds);
+        $legacy_writing_sccs = null;
+    }
+
+    // create LEGACY_BIOGRAPHY XML datastream from Doc Archive contents <=2019
+    if (isset($entry['bio_xml'])) {
+        $cwrc_ds = $object->constructDatastream('LEGACY_BIOGRAPHY_XML', 'M');
+        $cwrc_ds->label = $content_datastream_label."-b.xml";
+        $cwrc_ds->mimeType = 'text/xml';
+        $cwrc_ds->setContentFromString($legacy_biography_content);
+        $object->ingestDatastream($cwrc_ds);
+    }
+
+    // create LEGACY_BIOGRAPHY SCCS version datastream from Doc Archive contents <=2019
+    if (isset($entry['bio_sccs'])) {
+        //$legacy_writing_sccs = file_get_contents($legacy_dir."/sccs/".$entry['bio_sccs']);
+        $legacy_bio_sccs = $legacy_dir."/sccs/".$entry['bio_sccs'];
+        $cwrc_ds = $object->constructDatastream('LEGACY_BIOGRAPHY_SCCS', 'M');
+        $cwrc_ds->label = "s.".$content_datastream_label."-b.sgm";
+        $cwrc_ds->mimeType = 'application/octet-stream';
+        $cwrc_ds->setContentFromFile($legacy_bio_sccs, FALSE);
+        //$cwrc_ds->setContentFromString($legacy_writing_sccs);
+        $object->ingestDatastream($cwrc_ds);
+        $legacy_biography_sccs = null;
+    } 
+
+    // create combined content datastream
+    // with the legacy content
+    $cwrc_ds = $object->constructDatastream('CWRC', 'M');
+    $cwrc_ds->label = $content_datastream_label.".xml";
+    $cwrc_ds->mimeType = 'text/xml';
+    $cwrc_ds->setContentFromString($legacy_combined);
+    $object->ingestDatastream($cwrc_ds);
+    
+    // create DC datastream
+    create_DS_DC($dc_xml, $object);
+
+    // create MODS datastream
+    create_DS_MODS($mods_xml, $object);
+
+    // Workflow Datastream.
+    // We want to get all of the responsibilitie tags.
+    // For each responsibility create a workflow element.
+    // Create the MODS datastream.
+    create_DS_workflow_from_Source($content_v2_xml, $object);
+
+    // Create the Policy datastream.
+    if ( $policy != null && $policy!="NONE" ) 
+    {
+      //create_DS_POLICY($policy, $object);
+      $policy_ds
+          = new IslandoraXacml(
+              $object
+              , file_get_contents($policy)
+              );
+      $policy_ds->writeBackToFedora();
+    }
+
+    islandora_cwrc_writer_set_document_schema($object, $schema_obj);
+
+    try {
+      // Store the object.
+      islandora_add_object($object);
+      $file_count++;
+      drush_print("pid=$pid title=\"$title\" was added. #{$file_count} file migrated.");
+
+      // add a workflow stamp indicating that the object was ingested
+      $workflow = CWRCWorkflowAPI::fromDatastream($object['WORKFLOW']);
+      $workflow->addWorkflowStep(
+        $object->id, 
+        new WorkflowItem(WorkflowConst::WORKFLOW, array()),
+        new WorkflowItem(
+          WorkflowConst::ACTIVITY,
+          array(
+            "category" => "machine_processed",
+            'stamp' => 'orlando:SUB',
+            'status' => 'c',
+            "note" => "Initial ingest into the CWRC repository.",
+            )
+          )
+        );
+      CWRCWorkflowAPI::updateDatastream($workflow, $object);
+
+      // update content datastream with version 2.0 of the content
+      // UTF-8 and ISO 8601 dates
+      $object['CWRC']->setContentFromString($content_v2_xml);
+
+      // add a workflow stamp indicating that the object was ingested
+      $workflow = CWRCWorkflowAPI::fromDatastream($object['WORKFLOW']);
+      $workflow->addWorkflowStep(
+        $object->id, 
+        new WorkflowItem(WorkflowConst::WORKFLOW, array()),
+        new WorkflowItem(
+          WorkflowConst::ACTIVITY,
+          array(
+            "category" => "machine_processed",
+            'stamp' => 'orlando:SUB',
+            'status' => 'c',
+            "note" => "Conversion to version 2.0 of the Orlando format (UTF-8 and ISO 8601 dates).",
+            )
+          )
+        );
+      CWRCWorkflowAPI::updateDatastream($workflow, $object);
+break;
       //update URI's refences in entities
       if ($object['CWRC'])
       {

--- a/cwrc_migration_batch.drush.inc
+++ b/cwrc_migration_batch.drush.inc
@@ -97,6 +97,7 @@ function cwrc_migration_batch_drush_command() {
     'description' => 'Ingest Orlando Biography/Writing objects into CWRC',
     'options' => array(
       'legacy_dir' => 'path to directory of legacy source material',
+      'entity_mapping_file' => 'path to the JSON PID to standard name entity mapping file used to add URIs to bio/writing/event',
       'xslt_to_v2' => 'convert legacy bio/writ docs to version 2 (convert dates, utf-8)',
       'xslt_to_mods' => 'path to XSLT to convert biography/writing/event to mods',
       'xslt_mods_to_dc' => 'path to XSLT to convert mods to DC',
@@ -114,11 +115,12 @@ function cwrc_migration_batch_drush_command() {
   );
 
 
- 
+  # 2019-12-19: name/org/bibl 
   $items['cwrc_migration_batch_ingest_orlando_entities'] = array(
     'description' => 'Ingest Orlando Entity objects into CWRC',
     'options' => array(
       'legacy_dir' => 'path to directory of legacy source material',
+      'entity_mapping_file' => 'path to the JSON PID to standard name entity mapping file used to add URIs to bio/writing/event',
       'xslt_to_v2' => 'convert legacy Orlando docs to version 2 (convert dates, utf-8)',
       'xslt_to_dc' => 'path to XSLT to convert mods to DC',
       'main_ds_id' => 'Id of the main datastream (where content XML stored)',
@@ -1721,12 +1723,25 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
   // path to the input document files 
   $legacy_dir = drush_get_option('legacy_dir','/tmp/orlando/bio_writ');
 
-  // 
+  // path to entity mapping file
+  $entity_mapping_file = drush_get_option(
+    'entity_mapping_file'
+    , '/tmp/orlando/entity_mapping.json'
+    );
+
+  // UTF-8 plus legacy dates 
   $ext_home = drupal_get_path('module', 'cwrc_migration_batch') . '/';
   $xslt_to_v2 = drush_get_option(
     'xslt_to_v2'
     , $ext_home . 'transforms/orlando_legacy_to_v2_bio_writing.xsl'
   );
+
+  // merge bio/writing doc headers
+  $xslt_to_v3 = drush_get_option(
+    'xslt_to_v3'
+    , $ext_home . 'transforms/bioANDwritingTOentry.xsl'
+  );
+
   $xslt_to_mods = drush_get_option(
     'xslt_to_mods'
     , $ext_home . 'transforms/orlando_combined_bio_writing_TO_mods.xsl'
@@ -1765,7 +1780,6 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
   // Display the user.
   drush_print("User: " . $connection->connection->username);
 
-  
   // setup XSL 
   // http://www.saxonica.com/saxon-c/index.xml#debug
   //xslt_setup($xslt_bio_writ_to_v2, $bio_writ_to_v2_xslt_proc);
@@ -1776,13 +1790,20 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
   drush_print("XSLT Version: " . $saxonProc->version());
   
   $to_v2_xslt_proc = $saxonProc->newXsltProcessor();
+  $to_v3_xslt_proc = $saxonProc->newXsltProcessor();
   $to_mods_xslt_proc = $saxonProc->newXsltProcessor();
   $mods_to_dc_xslt_proc = $saxonProc->newXsltProcessor();
 
   $to_v2_xslt_proc->compileFromFile($xslt_to_v2);
+  $to_v3_xslt_proc->compileFromFile($xslt_to_v2);
   $to_mods_xslt_proc->compileFromFile($xslt_to_mods);
   $mods_to_dc_xslt_proc->compileFromFile($xslt_mods_to_dc);
 
+  // Initialize entity mapping: a JSON file ofPID to standard name 
+  // entity mapping file used to add URI's to bio/writing/event',
+  $entity_mapping = null;
+  entity_mapping_load($entity_mapping, $entity_mapping_file);
+  drush_print("Entity mapping file: " . $entity_mapping_file);
 
   // xpath to determine if PUB-C Orlando document - Biography/Writing/Event
   $xpathStrPub = "/*/ORLANDOHEADER/REVISIONDESC/RESPONSIBILITY[@WORKSTATUS='PUB' and @WORKVALUE='C']";
@@ -1860,10 +1881,10 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
         . "<?xml-model href='https://cwrc.ca/schemas/orlando_entry.rng' type='application/xml' schematypens='http://relaxng.org/ns/structure/1.0'?>\n"
         . "<?xml-stylesheet type='text/css' href='https://cwrc.ca/templates/css/orlando.css'?>\n"
         . $tmp_doctype
-        . "<ORLANDO ID='".$key."'>\n"
+        . "<ENTRY ID='".$key."'>\n"
         . ((isset($entry['bio_xml'])) ? preg_replace("/^.*(<BIOGRAPHY.+$)/s",'$1', $legacy_biography_content) : "")
         . ((isset($entry['writ_xml'])) ? preg_replace('/^.*(<WRITING.+$)/s','$1', $legacy_writing_content) : "")
-        . "</ORLANDO>"
+        . "</ENTRY>"
         ;
 
         
@@ -1871,7 +1892,7 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
 
 
     // build the version 2.0 of the biography / writing document
-    // UTF-8 + remove DOCTYPE
+    // UTF-8 + Legacy Dates + remove DOCTYPE
     $to_v2_xslt_proc->setSourceFromXdmValue(
       $saxonProc->parseXmlFromString($legacy_content)
     );
@@ -1880,6 +1901,13 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
     $content_v2_xml = str_replace($tmp_doctype , "" , $content_v2_xml);
 
     //drush_print($content_v2_xml);
+
+    // build the version 3.0 of the biography / writing document
+    // * merge bio/writing doc headers
+    $to_v3_xslt_proc->setSourceFromXdmValue(
+      $saxonProc->parseXmlFromString($content_v2_xml)
+    );
+    $content_v3_xml = $to_v3_xslt_proc->transformToString();
 
     // Build MODS XML.
     $to_mods_xslt_proc->setParameter(
@@ -1896,7 +1924,7 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
             );
     }
     $to_mods_xslt_proc->setSourceFromXdmValue(
-      $saxonProc->parseXmlFromString($content_v2_xml)
+      $saxonProc->parseXmlFromString($content_v3_xml)
       );
     $mods_xml = $to_mods_xslt_proc->transformToString();
 
@@ -1924,7 +1952,7 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
     // TODO: update 2019-12-20 based on new schema
     // determine collection PUB-C versus non-PUB-C based on workflow
     $content_dom = new DOMDocument();
-    $content_dom->loadXML($content_v2_xml);
+    $content_dom->loadXML($content_v3_xml);
     $xpathObj = new DOMXpath($content_dom); 
     $pubCRes = $xpathObj->query($xpathStrPub);
     $collection_pid = $collection_pid_non_pub_c;
@@ -2030,7 +2058,7 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
     // We want to get all of the responsibilitie tags.
     // For each responsibility create a workflow element.
     // Create the MODS datastream.
-    create_DS_workflow_from_Source($content_v2_xml, $object);
+    create_DS_workflow_from_Source($content_v3_xml, $object);
 
     // Create the Policy datastream.
     if ( $policy != null && $policy!="NONE" ) 
@@ -2089,7 +2117,29 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
           )
         );
       CWRCWorkflowAPI::updateDatastream($workflow, $object);
+
 break;
+      // update content datastream with version 3.0 of the content
+      // * merge bio/writing doc headers
+      $object['CWRC']->setContentFromString($content_v3_xml);
+
+      // add a workflow stamp indicating that the object was ingested
+      $workflow = CWRCWorkflowAPI::fromDatastream($object['WORKFLOW']);
+      $workflow->addWorkflowStep(
+        $object->id, 
+        new WorkflowItem(WorkflowConst::WORKFLOW, array()),
+        new WorkflowItem(
+          WorkflowConst::ACTIVITY,
+          array(
+            "category" => "machine_processed",
+            'stamp' => 'orlando:SUB',
+            'status' => 'c',
+            "note" => "Conversion to version 3.0 of the Orlando format (rearrange elements).",
+            )
+          )
+        );
+      CWRCWorkflowAPI::updateDatastream($workflow, $object);
+
       //update URI's refences in entities
       if ($object['CWRC'])
       {
@@ -2103,15 +2153,18 @@ break;
     }
 
   }
+
+  // write the entity mapping file
+  entity_mapping_write_to_file($entity_mapping, $entity_mapping_file);
+
   drush_print('Migration Complete');
   drush_print('Number of files migrated: ' . $file_count);
   drush_print('Number of errors: ' . $file_error_count);
-
 }
 
 
 /** 
- * CWRC migration batch - Entities to Orlando version 2 - 2016-11-29
+ * CWRC migration batch - Entities to Orlando version 2 - 2016-11-29 - 2019-12-19
  * workflow is pulled from the legacy Orlando format stored in subdir
  *
  */
@@ -2128,7 +2181,16 @@ function drush_cwrc_migration_batch_ingest_orlando_entities()
   drush_print("Orlando entity migration batch version 2.0");
 
   // path to the input document files 
-  $legacy_dir = drush_get_option('legacy_dir','/tmp/orlando/bio_writ');
+  $legacy_dir = drush_get_option(
+    'legacy_dir'
+    , '/tmp/orlando/bio_writ'
+    );
+
+  // path to entity mapping file
+  $entity_mapping_file = drush_get_option(
+    'entity_mapping_file'
+    , '/tmp/orlando/entity_mapping.json'
+    );
 
   // 
   $ext_home = drupal_get_path('module', 'cwrc_migration_batch') . '/';
@@ -2148,6 +2210,10 @@ function drush_cwrc_migration_batch_ingest_orlando_entities()
   $main_ds_id = drush_get_option(
     'main_ds_id'
     , 'MODS'
+  );
+  $entity_type = drush_get_option(
+    'entity_type'
+    , 'BIBL'
   );
   $collection_pid_pub_c = drush_get_option(
     'collection_pid_pub_c'
@@ -2196,6 +2262,11 @@ function drush_cwrc_migration_batch_ingest_orlando_entities()
   $to_v2_xslt_proc->compileFromFile($xslt_to_v2);
   $to_dc_xslt_proc->compileFromFile($xslt_to_dc);
 
+  // Initialize entity mapping: a JSON file ofPID to standard name 
+  // entity mapping file used to add URI's to bio/writing/event',
+  $entity_mapping = null;
+  entity_mapping_load($entity_mapping, $entity_mapping_file);
+  drush_print("Entity mapping file: " . $entity_mapping_file);
 
   // xpath to determine if PUB-C Orlando document -  BIBL Legacy XPath
   $xpathStrPub = "//RESPONSIBILITY[@WORKSTATUS='PUB' and @WORKVALUE='C']";
@@ -2229,7 +2300,7 @@ function drush_cwrc_migration_batch_ingest_orlando_entities()
 
     // If the object already exists then continue to next file.
     if (islandora_object_load($pid)) {
-      drush_print("object $object_name is already in fedora");
+      drush_print("object $pid is already in fedora");
       continue;
     }
     
@@ -2238,11 +2309,21 @@ function drush_cwrc_migration_batch_ingest_orlando_entities()
     // Load xml from a file.
     $legacy_content = file_get_contents($legacy_dir.$file_name);
 
-    // build the UTF-8 version 
+    // build the UTF-8 version with conversion of Orlando dates
     $to_clean_xslt_proc->setSourceFromXdmValue(
       $saxonProc->parseXmlFromString($legacy_content)
     );
     $clean_xml = $to_clean_xslt_proc->transformToString();
+
+    // add ID and PID to the entity mapping
+    // ToDo: assumption - use UTF-8 version
+    $legacy_id = entity_mapping_extract_id($xml);
+    if ( isset($pid) && isset($legacy_id) ) {
+      entity_mapping_add($entity_mapping, $legacy_id, $pid, $entity_type);
+    }
+    else {
+      drush_print("ID [$legacy_id] not found");
+    }
 
     // build the version 2.0 
     $to_v2_xslt_proc->setSourceFromXdmValue(
@@ -2379,6 +2460,7 @@ function drush_cwrc_migration_batch_ingest_orlando_entities()
 
       if ($add_pub_c_workflow==='yes')
       {
+        // ToDo: assume all name and org are pub-c as input authority lists don't contain workflow
         // add a workflow stamp indicating that the object was ingested
         $workflow = CWRCWorkflowAPI::fromDatastream($object['WORKFLOW']);
         $workflow->addWorkflowStep(
@@ -2404,10 +2486,13 @@ function drush_cwrc_migration_batch_ingest_orlando_entities()
     }
 
   }
+
+  // write the entity mapping file
+  entity_mapping_write_to_file($entity_mapping, $entity_mapping_file);
+
   drush_print('Migration Complete');
   drush_print('Number of files migrated: ' . $file_count);
   drush_print('Number of errors: ' . $file_error_count);
-
 }
 
 

--- a/cwrc_migration_batch.drush.inc
+++ b/cwrc_migration_batch.drush.inc
@@ -3192,7 +3192,7 @@ function cwrc_migration_batch_add_entity_refs($object, $ds_id, $entity_mapping)
       , "REF"
       , "STANDARD"
       , ISLANDORA_ORLANDO_MIGRATE_PERSON_ORG
-      , ORGNAME
+      , "ORGNAME"
       , $entity_mapping
     );
     $content = add_entity_references_via_element(
@@ -3202,7 +3202,7 @@ function cwrc_migration_batch_add_entity_refs($object, $ds_id, $entity_mapping)
       , "REF"
       , "DBREF"
       , ISLANDORA_ORLANDO_MIGRATE_BIBL
-      , BIBCIT 
+      , "BIBCIT"
       , $entity_mapping
     );
     $content = add_entity_references_via_element(
@@ -3212,7 +3212,7 @@ function cwrc_migration_batch_add_entity_refs($object, $ds_id, $entity_mapping)
       , "REF"
       , "DBREF"
       , ISLANDORA_ORLANDO_MIGRATE_BIBL
-      , BIBCIT 
+      , "BIBCIT" 
       , $entity_mapping
     );
 
@@ -3237,7 +3237,7 @@ function cwrc_migration_batch_add_entity_refs($object, $ds_id, $entity_mapping)
       , "valueURI"
       , ""
       , "orlando_migration/orlando_entity_lookup_person_org.xq"
-      , "BIBCIT" 
+      , "NAME" 
       , $entity_mapping
       );
     $ds->setContentFromString($content);

--- a/cwrc_migration_batch.drush.inc
+++ b/cwrc_migration_batch.drush.inc
@@ -1812,7 +1812,7 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
   $mods_to_dc_xslt_proc = $saxonProc->newXsltProcessor();
 
   $to_v2_xslt_proc->compileFromFile($xslt_to_v2);
-  $to_v3_xslt_proc->compileFromFile($xslt_to_v2);
+  $to_v3_xslt_proc->compileFromFile($xslt_to_v3);
   $to_mods_xslt_proc->compileFromFile($xslt_to_mods);
   $mods_to_dc_xslt_proc->compileFromFile($xslt_mods_to_dc);
 
@@ -1934,6 +1934,8 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
       $saxonProc->parseXmlFromString($content_v2_xml)
     );
     $content_v3_xml = $to_v3_xslt_proc->transformToString();
+
+    //print ("zzzzzzzzzzzzzzzzzzzz " . $content_v3_xml);
 
     // Build MODS XML.
     $to_mods_xslt_proc->setParameter(

--- a/cwrc_migration_batch.drush.inc
+++ b/cwrc_migration_batch.drush.inc
@@ -76,6 +76,7 @@ function cwrc_migration_batch_drush_command() {
     'description' => 'Ingest Orlando Biography/Writing/event objects into CWRC',
     'options' => array(
       'legacy_dir' => 'path to directory of legacy source material',
+      'entity_mapping_file' => 'path to the JSON PID to standard name entity mapping file used to add URIs to bio/writing/event',
       'xslt_to_v2' => 'convert legacy bio/writ docs to version 2 (convert dates, utf-8)',
       'xslt_to_mods' => 'path to XSLT to convert biography/writing/event to mods',
       'xslt_mods_to_dc' => 'path to XSLT to convert mods to DC',
@@ -1462,9 +1463,18 @@ function drush_cwrc_migration_batch_ingest_orlando_biography_writing ()
 
   // Initialize entity mapping: a JSON file ofPID to standard name 
   // entity mapping file used to add URI's to bio/writing/event',
-  $entity_mapping = null;
-  entity_mapping_load($entity_mapping, $entity_mapping_file);
-  drush_print("Entity mapping file: " . $entity_mapping_file);
+  try {
+    drush_print("Entity mapping file: " . $entity_mapping_file);
+    entity_mapping_load($entity_mapping, $entity_mapping_file);
+    drush_print("person: " . count($entity_mapping["NAME"]));
+    drush_print("org: " . count($entity_mapping["ORGNAME"]));
+    drush_print("bibl: " . count($entity_mapping["BIBCIT"]));
+    // write the entity mapping file
+    entity_mapping_write_to_file($entity_mapping, $entity_mapping_file);
+  } catch (Exception $e) {
+    drush_print($e);
+    exit();
+  }
 
   // xpath to determine if PUB-C Orlando document - Biography/Writing/Event
   $xpathStrPub = "/*/ORLANDOHEADER/REVISIONDESC/RESPONSIBILITY[@WORKSTATUS='PUB' and @WORKVALUE='C']";

--- a/cwrc_migration_batch.drush.inc
+++ b/cwrc_migration_batch.drush.inc
@@ -1390,6 +1390,12 @@ function drush_cwrc_migration_batch_ingest_orlando_biography_writing ()
   // path to the input document files 
   $legacy_dir = drush_get_option('legacy_dir','/tmp/orlando/bio_writ');
 
+  // path to entity mapping file
+  $entity_mapping_file = drush_get_option(
+    'entity_mapping_file'
+    , '/tmp/orlando/entity_mapping.json'
+    );
+
   // 
   $ext_home = drupal_get_path('module', 'cwrc_migration_batch') . '/';
   $xslt_to_v2 = drush_get_option(
@@ -1452,6 +1458,11 @@ function drush_cwrc_migration_batch_ingest_orlando_biography_writing ()
   $to_mods_xslt_proc->compileFromFile($xslt_to_mods);
   $mods_to_dc_xslt_proc->compileFromFile($xslt_mods_to_dc);
 
+  // Initialize entity mapping: a JSON file ofPID to standard name 
+  // entity mapping file used to add URI's to bio/writing/event',
+  $entity_mapping = null;
+  entity_mapping_load($entity_mapping, $entity_mapping_file);
+  drush_print("Entity mapping file: " . $entity_mapping_file);
 
   // xpath to determine if PUB-C Orlando document - Biography/Writing/Event
   $xpathStrPub = "/*/ORLANDOHEADER/REVISIONDESC/RESPONSIBILITY[@WORKSTATUS='PUB' and @WORKVALUE='C']";
@@ -1684,7 +1695,7 @@ function drush_cwrc_migration_batch_ingest_orlando_biography_writing ()
       //update URI's refences in entities
       if ($object['CWRC'])
       {
-        cwrc_migration_batch_add_entity_refs($object, "CWRC");
+        cwrc_migration_batch_add_entity_refs($object, "CWRC", $entity_mapping);
       }
     }
     catch (Exception $e) {
@@ -1694,6 +1705,10 @@ function drush_cwrc_migration_batch_ingest_orlando_biography_writing ()
     }
 
   }
+  
+  // write the entity mapping file
+  entity_mapping_write_to_file($entity_mapping, $entity_mapping_file);
+
   drush_print('Migration Complete');
   drush_print('Number of files migrated: ' . $file_count);
   drush_print('Number of errors: ' . $file_error_count);
@@ -2143,7 +2158,7 @@ break;
       //update URI's refences in entities
       if ($object['CWRC'])
       {
-        cwrc_migration_batch_add_entity_refs($object, "CWRC");
+        cwrc_migration_batch_add_entity_refs($object, "CWRC", $entity_mapping);
       }
     }
     catch (Exception $e) {
@@ -3105,7 +3120,7 @@ EOT;
  * (name/org/bibcit/textscope/standard/etc.) 
  *
  */
-function cwrc_migration_batch_add_entity_refs($object, $ds_id) 
+function cwrc_migration_batch_add_entity_refs($object, $ds_id, $entity_mapping) 
 {
 
   module_load_include('inc', 'islandora_cwrc_writer', 'includes/utilities');
@@ -3134,6 +3149,8 @@ function cwrc_migration_batch_add_entity_refs($object, $ds_id)
       , "REF"
       , null
       , ISLANDORA_ORLANDO_MIGRATE_PERSON_ORG
+      , "NAME"
+      , $entity_mapping
     );
     $content = add_entity_references_via_element(
       $content
@@ -3142,6 +3159,8 @@ function cwrc_migration_batch_add_entity_refs($object, $ds_id)
       , "REF"
       , "STANDARD"
       , ISLANDORA_ORLANDO_MIGRATE_PERSON_ORG
+      , "NAME"
+      , $entity_mapping
     );
     $content = add_entity_references_via_element(
       $content
@@ -3150,6 +3169,8 @@ function cwrc_migration_batch_add_entity_refs($object, $ds_id)
       , "REF"
       , "STANDARD"
       , ISLANDORA_ORLANDO_MIGRATE_PERSON_ORG
+      , ORGNAME
+      , $entity_mapping
     );
     $content = add_entity_references_via_element(
       $content
@@ -3158,6 +3179,8 @@ function cwrc_migration_batch_add_entity_refs($object, $ds_id)
       , "REF"
       , "DBREF"
       , ISLANDORA_ORLANDO_MIGRATE_BIBL
+      , BIBCIT 
+      , $entity_mapping
     );
     $content = add_entity_references_via_element(
       $content
@@ -3166,6 +3189,8 @@ function cwrc_migration_batch_add_entity_refs($object, $ds_id)
       , "REF"
       , "DBREF"
       , ISLANDORA_ORLANDO_MIGRATE_BIBL
+      , BIBCIT 
+      , $entity_mapping
     );
 
     // update object
@@ -3189,6 +3214,8 @@ function cwrc_migration_batch_add_entity_refs($object, $ds_id)
       , "valueURI"
       , ""
       , "orlando_migration/orlando_entity_lookup_person_org.xq"
+      , "BIBCIT" 
+      , $entity_mapping
       );
     $ds->setContentFromString($content);
   }

--- a/cwrc_migration_batch.drush.inc
+++ b/cwrc_migration_batch.drush.inc
@@ -99,6 +99,7 @@ function cwrc_migration_batch_drush_command() {
       'legacy_dir' => 'path to directory of legacy source material',
       'entity_mapping_file' => 'path to the JSON PID to standard name entity mapping file used to add URIs to bio/writing/event',
       'xslt_to_v2' => 'convert legacy bio/writ docs to version 2 (convert dates, utf-8)',
+      'xslt_to_v3' => 'update combined documents to version 3 (header)',
       'xslt_to_mods' => 'path to XSLT to convert biography/writing/event to mods',
       'xslt_mods_to_dc' => 'path to XSLT to convert mods to DC',
       'collection_pid_pub_c' => 'add object to the given collection if PUC-C workflow',
@@ -1817,9 +1818,18 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
 
   // Initialize entity mapping: a JSON file ofPID to standard name 
   // entity mapping file used to add URI's to bio/writing/event',
-  $entity_mapping = null;
-  entity_mapping_load($entity_mapping, $entity_mapping_file);
-  drush_print("Entity mapping file: " . $entity_mapping_file);
+  try {
+    drush_print("Entity mapping file: " . $entity_mapping_file);
+    entity_mapping_load($entity_mapping, $entity_mapping_file);
+    drush_print("person: " . count($entity_mapping["NAME"]));
+    drush_print("org: " . count($entity_mapping["ORGNAME"]));
+    drush_print("bibl: " . count($entity_mapping["BIBCIT"]));
+    // write the entity mapping file
+    entity_mapping_write_to_file($entity_mapping, $entity_mapping_file);
+  } catch (Exception $e) {
+    drush_print($e);
+    exit();
+  }
 
   // xpath to determine if PUB-C Orlando document - Biography/Writing/Event
   $xpathStrPub = "/*/ORLANDOHEADER/REVISIONDESC/RESPONSIBILITY[@WORKSTATUS='PUB' and @WORKVALUE='C']";
@@ -1832,7 +1842,7 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
   drush_print("Input legacy dir: " . $legacy_dir);
   $legacy_bio = $legacy_dir . "/biography/";
   $legacy_writ = $legacy_dir . "/writing/";
-  $legacy_sccs = $legacy_dir . "/sccs/";
+  $legacy_sccs = $legacy_dir . "/sccs_archive/";
 
   // build hash map of author ids with bio/writing doc attached
   // entries = array(
@@ -2024,7 +2034,7 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
     // create LEGACY_WRITING SCCS version datastream from Doc Archive contents <=2019
     if (isset($entry['writ_sccs'])) {
         //$legacy_writing_sccs = file_get_contents($legacy_dir."/sccs/".$entry['writ_sccs']);
-        $legacy_writing_sccs = $legacy_dir."/sccs/".$entry['writ_sccs'];
+        $legacy_writing_sccs = $legacy_sccs.$entry['writ_sccs'];
         $cwrc_ds = $object->constructDatastream('LEGACY_WRITING_SCCS', 'M');
         $cwrc_ds->label = "s.".$content_datastream_label."-w.sgm";
         $cwrc_ds->mimeType = 'application/octet-stream';
@@ -2046,7 +2056,7 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
     // create LEGACY_BIOGRAPHY SCCS version datastream from Doc Archive contents <=2019
     if (isset($entry['bio_sccs'])) {
         //$legacy_writing_sccs = file_get_contents($legacy_dir."/sccs/".$entry['bio_sccs']);
-        $legacy_bio_sccs = $legacy_dir."/sccs/".$entry['bio_sccs'];
+        $legacy_bio_sccs = $legacy_sccs.$entry['bio_sccs'];
         $cwrc_ds = $object->constructDatastream('LEGACY_BIOGRAPHY_SCCS', 'M');
         $cwrc_ds->label = "s.".$content_datastream_label."-b.sgm";
         $cwrc_ds->mimeType = 'application/octet-stream';
@@ -2134,7 +2144,6 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
         );
       CWRCWorkflowAPI::updateDatastream($workflow, $object);
 
-break;
       // update content datastream with version 3.0 of the content
       // * merge bio/writing doc headers
       $object['CWRC']->setContentFromString($content_v3_xml);

--- a/cwrc_migration_batch.drush.inc
+++ b/cwrc_migration_batch.drush.inc
@@ -131,6 +131,7 @@ function cwrc_migration_batch_drush_command() {
       'namespace' => 'pid namespace',
       'supplemental_filename' => 'supplemental content used to augment content',
       'add_pub_c_workflow' => 'add an additional workflow activity - pub-c',
+      'entity_type' => 'define the entity type (based on XML element name)',
     ),
     'examples' => array(
       'drush -u 1 cwrc_migration_batch_ingest_orlando_entities',
@@ -2279,9 +2280,18 @@ function drush_cwrc_migration_batch_ingest_orlando_entities()
 
   // Initialize entity mapping: a JSON file ofPID to standard name 
   // entity mapping file used to add URI's to bio/writing/event',
-  $entity_mapping = null;
-  entity_mapping_load($entity_mapping, $entity_mapping_file);
-  drush_print("Entity mapping file: " . $entity_mapping_file);
+  try {
+    drush_print("Entity mapping file: " . $entity_mapping_file);
+    entity_mapping_load($entity_mapping, $entity_mapping_file);
+    drush_print("person: " . count($entity_mapping["NAME"]));
+    drush_print("org: " . count($entity_mapping["ORGNAME"]));
+    drush_print("bibl: " . count($entity_mapping["BIBCIT"]));
+    // write the entity mapping file
+    entity_mapping_write_to_file($entity_mapping, $entity_mapping_file);
+  } catch (Exception $e) {
+    drush_print($e);
+    exit();
+  }
 
   // xpath to determine if PUB-C Orlando document -  BIBL Legacy XPath
   $xpathStrPub = "//RESPONSIBILITY[@WORKSTATUS='PUB' and @WORKVALUE='C']";
@@ -2332,12 +2342,13 @@ function drush_cwrc_migration_batch_ingest_orlando_entities()
 
     // add ID and PID to the entity mapping
     // ToDo: assumption - use UTF-8 version
-    $legacy_id = entity_mapping_extract_id($xml);
+    $legacy_id = entity_mapping_extract_id($clean_xml);
     if ( isset($pid) && isset($legacy_id) ) {
       entity_mapping_add($entity_mapping, $legacy_id, $pid, $entity_type);
+      drush_print("Entity ID [$legacy_id] added with value [$pid]");
     }
     else {
-      drush_print("ID [$legacy_id] not found");
+      drush_print("Entity ID [$legacy_id] not found");
     }
 
     // build the version 2.0 
@@ -2373,6 +2384,7 @@ function drush_cwrc_migration_batch_ingest_orlando_entities()
 
     // determine collection based on workflow
     $legacy_dom = new DOMDocument();
+    $legacy_dom->resolveExternals = true;
     $legacy_dom->loadXML($legacy_content);
     $xpathObj = new DOMXpath($legacy_dom); 
     $pubCRes = $xpathObj->query($xpathStrPub);
@@ -2502,7 +2514,9 @@ function drush_cwrc_migration_batch_ingest_orlando_entities()
 
   }
 
-  // write the entity mapping file
+  drush_print("person: " . count($entity_mapping["NAME"]));
+  drush_print("org: " . count($entity_mapping["ORGNAME"]));
+  drush_print("bibl: " . count($entity_mapping["BIBCIT"]));
   entity_mapping_write_to_file($entity_mapping, $entity_mapping_file);
 
   drush_print('Migration Complete');

--- a/includes/helpers.inc
+++ b/includes/helpers.inc
@@ -543,3 +543,58 @@ function build_hash_map(&$entries, $src_dir, $file_type, $file_sccs) {
     }
     closedir($src_dh);
 }
+
+/**
+  * Initialize the hash of entities
+**/
+function entity_mapping_init(&$entityMapping) {
+    $entityMapping = array(
+        "Person" => array(),
+        "Organization" => array(),
+        "Citation" => array(),
+        );
+}
+function entity_mapping_load(&$entityMapping, $entityJSONFilename) {
+  if (file_exists($entityJSONFilename)) {
+    $entityMapping = json_decode(file_get_contents($entityJSONFilename));
+  } else {
+    initEntity($entityMapping);
+  }
+}
+
+function entity_mapping_add(&$entity_mapping, $id, $pid, $entityType) {
+  $entity_mapping->$entityType->$id = $pid;
+}
+
+function entity_mapping_lookup($entity_mapping, $id, $entityType) {
+  return $entity_mapping->$entityType->$id;
+}
+
+function entity_mapping_write_to_file($entity_mapping, $entityJSONFilename) {
+  $fp = fopen($entityJSONFilename, 'w');
+  fwrite($fp, json_encode($resources));
+  fclose($fp);
+}
+
+/**
+ * get standard name or bibl id entity 
+ *
+ */
+function entity_mapping_extract_id ($xml)
+{
+  $xml_dom = new DOMDocument();
+  $xml_dom->loadXML($xml);
+  $id_xpath = new DOMXpath($xml_dom);
+  //$dc_title_xpath->registerNamespace("oai_dc", "http://www.openarchives.org/OAI/2.0/oai_dc/");
+  //$dc_title_xpath->registerNamespace("dc", "http://purl.org/dc/elements/1.1/");
+  //$tmp = $dc_title_xpath->query('/oai_dc:dc/dc:title');
+  $tmp = $id_xpath->query('/AUTHORITYITEM/@STANDARD || /BIBLIOGRAPHY_ENTRY/@BI_ID');
+
+  $id = $tmp->item(0)->nodeValue;
+
+  return $id;
+}
+
+
+
+

--- a/includes/helpers.inc
+++ b/includes/helpers.inc
@@ -574,30 +574,36 @@ function build_hash_map(&$entries, $src_dir, $file_type, $file_sccs) {
 **/
 function entity_mapping_init(&$entityMapping) {
     $entityMapping = array(
-        "Person" => array(),
-        "Organization" => array(),
-        "Citation" => array(),
+        "NAME" => array(),
+        "ORGNAME" => array(),
+        "BIBCIT" => array(),
         );
 }
 function entity_mapping_load(&$entityMapping, $entityJSONFilename) {
   if (file_exists($entityJSONFilename)) {
-    $entityMapping = json_decode(file_get_contents($entityJSONFilename));
+    $entityMapping = json_decode(file_get_contents($entityJSONFilename), true);
   } else {
-    initEntity($entityMapping);
+    entity_mapping_init($entityMapping);
   }
 }
 
-function entity_mapping_add(&$entity_mapping, $id, $pid, $entityType) {
-  $entity_mapping->$entityType->$id = $pid;
+function entity_mapping_add(&$entityMapping, $id, $pid, $entityType) {
+
+  //$entity_mapping->$entityType->$id = $pid;
+  $entityMapping[$entityType][$id] = $pid;
 }
 
-function entity_mapping_lookup($entity_mapping, $id, $entityType) {
-  return $entity_mapping->$entityType->$id;
+function entity_mapping_lookup($entityMapping, $id, $entityType) {
+  //return $entity_mapping->$entityType->$id;
+  return $entityMapping[$entityType][$id];
 }
 
-function entity_mapping_write_to_file($entity_mapping, $entityJSONFilename) {
+function entity_mapping_write_to_file($entityMapping, $entityJSONFilename) {
   $fp = fopen($entityJSONFilename, 'w');
-  fwrite($fp, json_encode($resources));
+  if (!$fp) {
+    throw new Exception('file open failed');
+  }
+  fwrite($fp, json_encode($entityMapping));
   fclose($fp);
 }
 
@@ -613,7 +619,7 @@ function entity_mapping_extract_id ($xml)
   //$dc_title_xpath->registerNamespace("oai_dc", "http://www.openarchives.org/OAI/2.0/oai_dc/");
   //$dc_title_xpath->registerNamespace("dc", "http://purl.org/dc/elements/1.1/");
   //$tmp = $dc_title_xpath->query('/oai_dc:dc/dc:title');
-  $tmp = $id_xpath->query('/AUTHORITYITEM/@STANDARD || /BIBLIOGRAPHY_ENTRY/@BI_ID');
+  $tmp = $id_xpath->query('/AUTHORITYITEM/@STANDARD | /BIBLIOGRAPHY_ENTRY/@BI_ID');
 
   $id = $tmp->item(0)->nodeValue;
 

--- a/includes/helpers.inc
+++ b/includes/helpers.inc
@@ -512,3 +512,34 @@ function lookup_uri_by_string(
 } 
 
 
+/**
+ * build hash array of entry id's and associated file names
+ * */
+function build_hash_map(&$entries, $src_dir, $file_type, $file_sccs) {
+
+    $src_dh = opendir($src_dir);
+    while (FALSE !== ($file_name = readdir($src_dh))) {
+
+        //drush_print($file_name."\n");
+
+        // If the file is a directory then continue to next file.
+        if (is_dir($file_name)) {
+            continue;
+        }
+
+        //$file_name_xml = preg_replace('/(\.sgm)$/','.xml', $file_name);
+        //print("xml:" . $file_name_xml."\n");
+
+        $entry_id = preg_replace('/^([a-zA-Z_0-9]{6,6})-[wb]\.xml/','$1', $file_name);
+        $entry_type = preg_replace('/^[a-zA-Z_0-9]{6,6}-([wb])\.xml/','$1', $file_name);                                        
+
+        if (!empty($entries[$entry_id])) {
+            $entries[$entry_id][$file_type] = $file_name;
+            $entries[$entry_id][$file_sccs] = "s.".$entry_id."-".$entry_type.".sgm";
+        } else {
+            $entries[$entry_id] = array("$file_type" => "$file_name");
+            $entries[$entry_id][$file_sccs] = "s.".$entry_id."-".$entry_type.".sgm";
+        }                                                                                                                   
+    }
+    closedir($src_dh);
+}

--- a/includes/helpers.inc
+++ b/includes/helpers.inc
@@ -338,6 +338,8 @@ function add_entity_references_via_element(
     , $attr_new
     , $attr_src
     , $xquery_id 
+    , $entity_type
+    , $entity_mapping
     )
 {
   $dom = new DOMDocument;
@@ -354,6 +356,8 @@ function add_entity_references_via_element(
     , $attr_new
     , $attr_src
     , $xquery_id 
+    , $entity_type
+    , $entity_mapping
   );
   
 }
@@ -370,6 +374,8 @@ function add_entity_references_via_xpath(
     , $attr_new
     , $attr_src
     , $xquery_id 
+    , $entity_type
+    , $entity_mapping
     )
 {
   $dom = new DOMDocument;
@@ -388,6 +394,8 @@ function add_entity_references_via_xpath(
     , $attr_new
     , $attr_src
     , $xquery_id 
+    , $entity_type
+    , $entity_mapping
   );
 }
 
@@ -404,6 +412,8 @@ function add_entity_references(
     , $attr_new
     , $attr_src
     , $xquery_id 
+    , $entity_type
+    , $entity_mapping
     )
 {
   if($nodes instanceof DOMNodeList)
@@ -437,35 +447,15 @@ function add_entity_references(
       // lookup and set the URI reference
       if (!$domElement->hasAttribute($attr_new))
       {
-        // is the new attribute already present?
-        // if no then add based on a lookup in the entity set
-        // lookup_entity_given_orlando_standard();
-        $attr_ref_value = lookup_uri_by_string(
-            $lookup_str
-            , $entity_cmodel
-            , $xquery_id
-            );
-        
-        $tmp_array = json_decode($attr_ref_value);
 
-        // may return a list of pids
-        // grap the first that is present in Fedora 
-        // json look like the following: { "pid" : [] }
-        $pid = null;
-        if ($tmp_array->pids)
-        { 
-          $iter = 0;
-          do 
-          {
-            $tmp_pid = $tmp_array->pids[$iter];
-            if (islandora_object_load($tmp_pid))
-            {
-              $pid = $tmp_array->pids[$iter];
-            }
-            $iter++;
-          } while ($iter < count($tmp_array->pids) ) ;
+        // lookup PID
+        if (isset($xquery_id)) {
+          $pid = lookup_id_in_XML_database($lookup_str, $entity_cmodel, $xquery_id);
+        } else if (isset($entity_mapping) && isset($entity_type)) {
+          $pid = entity_mapping_lookup($entity_mapping, $lookup_str, $entity_type);
         }
 
+        // update XML element node with new attribute
         if (!empty($attr_new) and !empty($pid))
         {
           // writin the entity uri (base + PID)
@@ -488,8 +478,43 @@ function add_entity_references(
 
 
 /**
+ * lookup standard_name / bibcit in XML Database 
+ */
+function lookup_id_in_XML_database($lookup_str, $entity_cmodel, $xquery_id) 
+{
+  // is the new attribute already present?
+  // if no then add based on a lookup in the entity set
+  // lookup_entity_given_orlando_standard();
+  $attr_ref_value = lookup_uri_by_string(
+      $lookup_str
+      , $entity_cmodel
+      , $xquery_id
+      );
+  
+  $tmp_array = json_decode($attr_ref_value);
+
+  // may return a list of pids
+  // grap the first that is present in Fedora 
+  // json look like the following: { "pid" : [] }
+  $pid = null;
+  if ($tmp_array->pids)
+  { 
+    $iter = 0;
+    do 
+    {
+      $tmp_pid = $tmp_array->pids[$iter];
+      if (islandora_object_load($tmp_pid))
+      {
+        $pid = $tmp_array->pids[$iter];
+      }
+      $iter++;
+    } while ($iter < count($tmp_array->pids) ) ;
+  }
+  return $pid;
+}
+
+/**
  * lookup the URL based on a unique string
- *
  */
 function lookup_uri_by_string(
   $lookup_str

--- a/includes/helpers.inc
+++ b/includes/helpers.inc
@@ -449,10 +449,10 @@ function add_entity_references(
       {
 
         // lookup PID
-        if (isset($xquery_id)) {
-          $pid = lookup_id_in_XML_database($lookup_str, $entity_cmodel, $xquery_id);
-        } else if (isset($entity_mapping) && isset($entity_type)) {
+        if (isset($entity_mapping) && isset($entity_type)) {
           $pid = entity_mapping_lookup($entity_mapping, $lookup_str, $entity_type);
+        } else if (isset($xquery_id)) {
+          $pid = lookup_id_in_XML_database($lookup_str, $entity_cmodel, $xquery_id);
         }
 
         // update XML element node with new attribute
@@ -464,7 +464,7 @@ function add_entity_references(
         }
         else
         {
-          drush_print("ERROR: [$context] not found with lookup [$lookup_str] for [$domElement->nodeValue] ref: [$attr_ref_value]");
+          drush_print("ERROR: [$context] not found with lookup [$lookup_str] for [$domElement->nodeValue] ref: [$attr_ref_value] pid: [$pid] entity_type: [$entity_type]");
         }
       }
       else

--- a/transforms/orlando_combined_bio_writing_TO_mods.xsl
+++ b/transforms/orlando_combined_bio_writing_TO_mods.xsl
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ORLANDO [ <!ENTITY % character_entities SYSTEM "http://cwrc.ca/schemas/character_entities.dtd"> %character_entities; ]>
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+
+    <xsl:output encoding="UTF-8" method="xml" indent="yes" omit-xml-declaration="no"/>
+    <xsl:include href="lib_orlando_date_helper.xsl"/>
+
+    <!--
+    * extract the MODS information section from an 
+    * Orlando biography or writing document
+    * 
+    * specifications: https://docs.google.com/a/ualberta.ca/document/d/1aGHGOxxsR9w65GDlKdxWBnNF5Y3Jl2RYlbFms_8Iiyo/edit
+    *
+    * final version stored in Orlando Delivery System DB
+    
+    -->
+
+    <!-- input parameter, the name of the original XML (SGML) file) -->
+    <xsl:param name="param_original_id" select="'xxxxxx'"/>
+    <xsl:param name="param_original_bio_filename" select="''"/>
+    <xsl:param name="param_original_writ_filename" select="''"/>
+
+
+    <!-- root element - assumes start with an Orlando bio or writing document -->
+    <xsl:template match="/">
+        <mods xmlns="http://www.loc.gov/mods/v3" xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/mods.xsd">
+
+            <titleInfo>
+                <title>
+                    <xsl:choose>
+                        <xsl:when test="ORLANDO">
+                            <!-- might be both bio and writ sections: use first -->
+                            <xsl:value-of select="/ORLANDO/(BIOGRAPHY|WRITING|DOCUMENTATION)[1]/ORLANDOHEADER/FILEDESC/TITLESTMT/DOCTITLE/text()"/>
+                        </xsl:when>
+                        <xsl:when test="BIOGRAPHY | WRITING | DOCUMENTATION">
+                            <xsl:value-of select="/(BIOGRAPHY|WRITING|DOCUMENTATION)/ORLANDOHEADER/FILEDESC/TITLESTMT/DOCTITLE/text()"/>
+                        </xsl:when>
+                        <xsl:when test="EVENT" xml:space="default">
+                            <xsl:variable name="TEXT_TO_SUBSTRING" select="normalize-space(/EVENT/CHRONEVENT/CHRONSTRUCT/CHRONPROSE)" xml:space="default"/>
+                            <xsl:value-of select="/EVENT/CHRONEVENT/CHRONSTRUCT/(DATE|DATERANGE|DATESTRUCT)/text()"/>
+                            <xsl:text>: </xsl:text>
+                            <!-- <xsl:value-of select="/EVENT/CHRONEVENT/CHRONSTRUCT/CHRONPROSE"></xsl:value-of> -->
+                            <!-- build snippet from longer chronprose, break at a "space", and restrict output to a max of "n" characters -->
+                            <xsl:value-of select="substring($TEXT_TO_SUBSTRING, 1, 40 + string-length(substring-before(substring($TEXT_TO_SUBSTRING, 41),' ')))" xml:space="default"/>
+                            <xsl:text>...</xsl:text>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:text>zzzz Error zzzz</xsl:text>
+                        </xsl:otherwise>
+                    </xsl:choose>
+
+                </title>
+            </titleInfo>
+
+            <language>
+                <languageTerm authority="iso639-2b" type="text">English</languageTerm>
+            </language>
+
+            <relatedItem type="host">
+                <titleInfo>
+                    <title>Orlando: Women's Writing in the British Isles from the Beginnings to the Present</title>
+                </titleInfo>
+                <name type="personal">
+                    <namePart type="given">Susan</namePart>
+                    <namePart type="family">Brown</namePart>
+                    <role>
+                        <roleTerm authority="marcrelator" type="text">Editor</roleTerm>
+                    </role>
+                </name>
+                <name type="personal">
+                    <namePart type="given">Patricia</namePart>
+                    <namePart type="family">Clements</namePart>
+                    <role>
+                        <roleTerm authority="marcrelator" type="text">Editor</roleTerm>
+                    </role>
+                </name>
+                <name type="personal">
+                    <namePart type="given">Isobel</namePart>
+                    <namePart type="family">Grundy</namePart>
+                    <role>
+                        <roleTerm authority="marcrelator" type="text">Editor</roleTerm>
+                    </role>
+                </name>
+                <originInfo>
+                    <dateIssued encoding="w3cdtf">
+                        <xsl:call-template name="convert_mla_to_iso">
+                            <!-- might be both bio and writ sections: use first -->
+                            <xsl:with-param name="INPUT_DATE" select="/*/(BIOGRAPHY|WRITING)[1]/ORLANDOHEADER/REVISIONDESC/(RESPONSIBILITY[@WORKSTATUS='PUB' and @WORKVALUE='C'])[1]/DATE/text()"/>
+                        </xsl:call-template>
+                    </dateIssued>
+                    <place>
+                        <placeTerm type="text">Cambridge, United Kingdom</placeTerm>
+                    </place>
+                    <publisher>Cambridge University Press</publisher>
+                </originInfo>
+            </relatedItem>
+
+            <identifier type="local">
+                <xsl:value-of select="$param_original_id"/>
+            </identifier>
+            <xsl:if test="$param_original_bio_filename != ''">
+                <identifier type="local">
+                    <xsl:value-of select="$param_original_bio_filename"/>
+                </identifier>
+            </xsl:if>
+            <xsl:if test="$param_original_writ_filename != ''">
+                <identifier type="local">
+                    <xsl:value-of select="$param_original_writ_filename"/>
+                </identifier>
+            </xsl:if>
+
+            <location>
+                <url>http://orlando.cambridge.org/</url>
+            </location>
+
+            <accessCondition type="use and reproduction" xlink:href="http://cwrc.ca/license/the-orlando-project-license.html">
+                <xsl:text>Access to this resource is restricted by a </xsl:text>
+                <a rel="license" href="http://cwrc.ca/license/the-orlando-project-license.html">licence</a>
+                <xsl:text> between the University of Alberta and Cambridge University Press</xsl:text>
+            </accessCondition>
+
+            <note type="researchNote">
+                <xsl:value-of select="/*/(BIOGRAPHY|WRITING|DOCUMENTATION)[1]/DIV0/STANDARD"/>
+            </note>
+
+
+            <!-- 
+                 2013-05-25
+                 decided to put the <recordInfo> information in the Workflow datastream, 
+                 but I'm wondering if we should be consistent, and approach the record 
+                 information in the same way we are approaching the rights information, i.e., 
+                 instead of using the Rights datastream, we are using the <accessCondition> 
+                 element in MODS. So, instead of using the Workflow datastream, maybe we 
+                 should use the <recordInfo> element in MODS.  This way, all of our metadata 
+                 "lives" in the same place (the MODS datastream), rather than parts of it 
+                 being fractured and hived off and "living" in the Workflow datastream 
+                 (the record information).
+                
+                 2013-05-27
+                 *<recordInfo> information only applies to the MODS record, not the resource 
+                 it is describing (in this case, the Orlando document).  Therefore because 
+                 the MODS record won't change, although the Orlando document resource might 
+                 change, we can treat the MODS record as static, and it won't change over time.  
+                 Consequently, we can add the <recordChangeDate> element that I took out on 
+                 Friday.  
+            -->
+            <recordInfo>
+                <recordContentSource>Orlando, Cambridge University Press</recordContentSource>
+                <recordCreationDate encoding="w3cdtf">
+                    <xsl:value-of select="format-date(current-date(),'[Y0001]-[M01]-[D01]')"/>
+                </recordCreationDate>
+                <recordChangeDate encoding="w3cdtf">
+                    <xsl:value-of select="format-date(current-date(),'[Y0001]-[M01]-[D01]')"/>
+                </recordChangeDate>
+                <recordIdentifier source="The Orlando Project">
+                    <xsl:value-of select="$param_original_id"/>
+                </recordIdentifier>
+                <recordOrigin>
+                    <xsl:text>MODS record has been created from an SGML record using an XSLT stylesheet.</xsl:text>
+                </recordOrigin>
+                <languageOfCataloging>
+                    <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
+                    <languageTerm type="text">English</languageTerm>
+                </languageOfCataloging>
+            </recordInfo>
+
+            <xsl:if test="/*/(BIOGRAPHY|WRITING)">
+              <subject>
+                <name type="personal">
+                    <xsl:value-of select="/*/(BIOGRAPHY|WRITING)[1]/DIV0/STANDARD/text()"/>
+                </name>
+                </subject>
+              </xsl:if>
+
+        </mods>
+
+    </xsl:template>
+
+
+</xsl:stylesheet>

--- a/transforms/orlando_combined_bio_writing_TO_mods.xsl
+++ b/transforms/orlando_combined_bio_writing_TO_mods.xsl
@@ -31,10 +31,10 @@
                     <xsl:choose>
                         <xsl:when test="ORLANDO">
                             <!-- might be both bio and writ sections: use first -->
-                            <xsl:value-of select="/ORLANDO/(BIOGRAPHY|WRITING|DOCUMENTATION)[1]/ORLANDOHEADER/FILEDESC/TITLESTMT/DOCTITLE/text()"/>
+                            <xsl:value-of select="/ORLANDO/(BIOGRAPHY|WRITING|DOCUMENTATION|ENTRY)[1]/ORLANDOHEADER/FILEDESC/TITLESTMT/DOCTITLE/text()"/>
                         </xsl:when>
-                        <xsl:when test="BIOGRAPHY | WRITING | DOCUMENTATION">
-                            <xsl:value-of select="/(BIOGRAPHY|WRITING|DOCUMENTATION)/ORLANDOHEADER/FILEDESC/TITLESTMT/DOCTITLE/text()"/>
+                        <xsl:when test="BIOGRAPHY | WRITING | DOCUMENTATION | ENTRY">
+                            <xsl:value-of select="/(BIOGRAPHY|WRITING|DOCUMENTATION|ENTRY)/ORLANDOHEADER/FILEDESC/TITLESTMT/DOCTITLE/text()"/>
                         </xsl:when>
                         <xsl:when test="EVENT" xml:space="default">
                             <xsl:variable name="TEXT_TO_SUBSTRING" select="normalize-space(/EVENT/CHRONEVENT/CHRONSTRUCT/CHRONPROSE)" xml:space="default"/>


### PR DESCRIPTION
Stage one of the following change:

Update the Orlando batch migration process to use a combined biography and writing document instead of the legacy format where biography and writing documents for a given author were separate

Secondly, utilized a cached version of the entities to apply URIs to biography, writing, and event documents. The cache stores the legacy id attached to entities (i.e., person, organizations, and bibliography) and maps to the PID assigned by Islandora. This allows URI to be added to the name, orgname, and bibcit elements in biography, writing, and event documents. the previous approach leveraged and XML database query however a local cache increase the speed of the migration.