### PR TITLE
Feature/orlando migration revisions june

### DIFF
--- a/cwrc_migration_batch.drush.inc
+++ b/cwrc_migration_batch.drush.inc
@@ -2411,9 +2411,19 @@ function drush_cwrc_migration_batch_ingest_orlando_entities()
       drush_print("Entity ID [$legacy_id] not found");
     }
 
+    if ($main_ds_id=='MODS') {
+      // update URI's refences in bibliographic entities
+      // requires UTF-8 
+      $uri_xml = cwrc_migration_batch_add_entity_refs_content($clean_xml, $main_ds_id, $entity_mapping);
+    }
+    else {
+      // for other entity 
+      $uri_xml = $clean_xml;
+    }
+
     // build the version 2.0 
     $to_v2_xslt_proc->setSourceFromXdmValue(
-      $saxonProc->parseXmlFromString($clean_xml)
+      $saxonProc->parseXmlFromString($uri_xml)
     );
     if ($supplemental_filename)
     {
@@ -2554,8 +2564,29 @@ function drush_cwrc_migration_batch_ingest_orlando_entities()
         );
       CWRCWorkflowAPI::updateDatastream($workflow, $object);
 
+      // update URI's refences in entities
+      // requires UTF-8 
+      $object[$main_ds_id]->setContentFromString($uri_xml);
+
+      // add a workflow stamp indicating that the object was ingested
+      $workflow = CWRCWorkflowAPI::fromDatastream($object['WORKFLOW']);
+      $workflow->addWorkflowStep(
+        $object->id,
+        new WorkflowItem(WorkflowConst::WORKFLOW, array()),
+        new WorkflowItem(
+          WorkflowConst::ACTIVITY,
+          array(
+            "category" => "machine_processed",
+            'stamp' => 'orlando:PUB',
+            'status' => 'c',
+            "note" => "Add URIs to entities.",
+            )
+          )
+        );
+      CWRCWorkflowAPI::updateDatastream($workflow, $object);
+
       // update content datastream with version 2.0 of the content
-      // UTF-8 and ISO 8601 dates
+      // UTF-8 and ISO 8601 dates (from previous steps)
       $object[$main_ds_id]->setContentFromString($content_v2_xml);
 
       // add a workflow stamp indicating that the object was ingested
@@ -2569,7 +2600,7 @@ function drush_cwrc_migration_batch_ingest_orlando_entities()
             "category" => "machine_processed",
             'stamp' => 'orlando:SUB',
             'status' => 'c',
-            "note" => "Conversion to version 2.0 of the Orlando format (UTF-8 and ISO 8601 dates).",
+            "note" => "Conversion to version 2.0 of the Orlando format.",
             )
           )
         );
@@ -3403,9 +3434,87 @@ function cwrc_migration_batch_verify_fedora($item_type, $pid, $file_name)
   }
 
   return $status;
-
 }
 
+
+function cwrc_migration_batch_add_entity_refs_content($content, $ds_id, $entity_mapping) 
+{
+
+  // add entity references to elements in content
+  if ($ds_id != "MODS") {
+    $content = add_entity_references_via_element(
+      $content
+      , "info:fedora/cwrc:person-entityCModel"
+      , "STANDARD"
+      , "REF"
+      , null
+      , ISLANDORA_ORLANDO_MIGRATE_PERSON_ORG
+      , "NAME"
+      , $entity_mapping
+    );
+  }
+  $content = add_entity_references_via_element(
+    $content
+    , "info:fedora/cwrc:person-entityCModel"
+    , "NAME"
+    , "REF"
+    , "STANDARD"
+    , ISLANDORA_ORLANDO_MIGRATE_PERSON_ORG
+    , "NAME"
+    , $entity_mapping
+  );
+  $content = add_entity_references_via_element(
+    $content
+    , "info:fedora/cwrc:organization-entityCModel"
+    , "ORGNAME"
+    , "REF"
+    , "STANDARD"
+    , ISLANDORA_ORLANDO_MIGRATE_PERSON_ORG
+    , "ORGNAME"
+    , $entity_mapping
+  );
+  if ($ds_id != "MODS") {
+    $content = add_entity_references_via_element(
+      $content
+      , "info:fedora/cwrc:citationCModel"
+      , "TEXTSCOPE"
+      , "REF"
+      , "DBREF"
+      , ISLANDORA_ORLANDO_MIGRATE_BIBL
+      , "BIBCIT"
+      , $entity_mapping
+    );
+    $content = add_entity_references_via_element(
+      $content
+      , "info:fedora/cwrc:citationCModel"
+      , "BIBCIT"
+      , "REF"
+      , "DBREF"
+      , ISLANDORA_ORLANDO_MIGRATE_BIBL
+      , "BIBCIT" 
+      , $entity_mapping
+    );
+  }
+
+  // update MODS with a URI
+  // XQuery XMLDatabase version 
+  // if ($ds_id == "MODS") {
+  // $content = add_entity_references_via_xpath(
+    // $content
+    // , "info:fedora/cwrc:person-entityCModel"
+    // , "/mods:mods/mods:subject/mods:name[@type=\"personal\"]"
+    // , "valueURI"
+    // , ""
+    // , "orlando_migration/orlando_entity_lookup_person_org.xq"
+    // , "NAME" 
+    // , $entity_mapping
+    // );
+  // }
+
+
+  return $content;
+
+}
 
 /** 
  * CWRC migration batch - add @REF attributes to the core entity elements
@@ -3433,85 +3542,11 @@ function cwrc_migration_batch_add_entity_refs($object, $ds_id, $entity_mapping)
   else {
     $content = $ds->content;
 
-    // add entity references to elements in content
-    $content = add_entity_references_via_element(
-      $content
-      , "info:fedora/cwrc:person-entityCModel"
-      , "STANDARD"
-      , "REF"
-      , null
-      , ISLANDORA_ORLANDO_MIGRATE_PERSON_ORG
-      , "NAME"
-      , $entity_mapping
-    );
-    $content = add_entity_references_via_element(
-      $content
-      , "info:fedora/cwrc:person-entityCModel"
-      , "NAME"
-      , "REF"
-      , "STANDARD"
-      , ISLANDORA_ORLANDO_MIGRATE_PERSON_ORG
-      , "NAME"
-      , $entity_mapping
-    );
-    $content = add_entity_references_via_element(
-      $content
-      , "info:fedora/cwrc:organization-entityCModel"
-      , "ORGNAME"
-      , "REF"
-      , "STANDARD"
-      , ISLANDORA_ORLANDO_MIGRATE_PERSON_ORG
-      , "ORGNAME"
-      , $entity_mapping
-    );
-    $content = add_entity_references_via_element(
-      $content
-      , "info:fedora/cwrc:citationCModel"
-      , "TEXTSCOPE"
-      , "REF"
-      , "DBREF"
-      , ISLANDORA_ORLANDO_MIGRATE_BIBL
-      , "BIBCIT"
-      , $entity_mapping
-    );
-    $content = add_entity_references_via_element(
-      $content
-      , "info:fedora/cwrc:citationCModel"
-      , "BIBCIT"
-      , "REF"
-      , "DBREF"
-      , ISLANDORA_ORLANDO_MIGRATE_BIBL
-      , "BIBCIT" 
-      , $entity_mapping
-    );
+    $content = cwrc_migration_batch_add_entity_refs_content($content, $ds_id, $entity_mapping);
 
     // update object
     $ds->setContentFromString($content);
   }
-
-  //update MODS with a URI
-  $ds = $object['MODS'];
-  if (!$ds)
-  {
-    drush_print("Error: datastream [$ds_id] not found $pid");
-  }
-  else 
-  {
-    $content = $ds->content;
-    
-    $content = add_entity_references_via_xpath(
-        $content
-      , "info:fedora/cwrc:person-entityCModel"
-      , "/mods:mods/mods:subject/mods:name[@type=\"personal\"]"
-      , "valueURI"
-      , ""
-      , "orlando_migration/orlando_entity_lookup_person_org.xq"
-      , "NAME" 
-      , $entity_mapping
-      );
-    $ds->setContentFromString($content);
-  }
-
 
   // add a workflow stamp indicating that the object was ingested
   $workflow = CWRCWorkflowAPI::fromDatastream($object['WORKFLOW']);

--- a/cwrc_migration_batch.drush.inc
+++ b/cwrc_migration_batch.drush.inc
@@ -2445,6 +2445,12 @@ function drush_cwrc_migration_batch_ingest_orlando_entities()
     $cwrc_ds->setContentFromString($legacy_content);
     $object->ingestDatastream($cwrc_ds);
  
+    // create LEGACY_ENTITY datastream from Doc Archive contents <=2019
+    $legacy_ds = $object->constructDatastream('LEGACY_BIOGRAPHY_XML', 'M');
+    $legacy_ds->label = "legacy_" . $file_name;
+    $legacy_ds->mimeType = 'text/xml';
+    $legacy_ds->setContentFromString($legacy_content);
+    $object->ingestDatastream($legacy_ds);
     
     // create DC datastream
     create_DS_DC($dc_xml, $object);

--- a/cwrc_migration_batch.drush.inc
+++ b/cwrc_migration_batch.drush.inc
@@ -1882,7 +1882,9 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
     drush_print("Entry: " . $key);
 
     // generate an id for the object
-    $pid = $connection->repository->getnextIdentifier($namespace, TRUE);
+    // $pid = $connection->repository->getnextIdentifier($namespace, TRUE);
+    // Use $key as the PID for example, orlando:austja 
+    $pid = $namespace . ":" . $key; 
 
     // Strip out the .xml from the file name and store in the variable.
     //preg_match('/[a-z0-9-_]*/', $file_name, $object_name);
@@ -1897,7 +1899,6 @@ function drush_cwrc_migration_batch_ingest_orlando_combine_biography_writing ()
       drush_print("object $pid - $key is already in fedora");
       continue;
     }
-
 
     // get legacy files
     $legacy_writing_content = null;

--- a/cwrc_migration_batch.drush.inc
+++ b/cwrc_migration_batch.drush.inc
@@ -2413,7 +2413,7 @@ function drush_cwrc_migration_batch_ingest_orlando_entities()
 
     // build the version 2.0 
     $to_v2_xslt_proc->setSourceFromXdmValue(
-      $saxonProc->parseXmlFromString($legacy_content)
+      $saxonProc->parseXmlFromString($clean_xml)
     );
     if ($supplemental_filename)
     {
@@ -2484,7 +2484,7 @@ function drush_cwrc_migration_batch_ingest_orlando_entities()
     $object->ingestDatastream($cwrc_ds);
  
     // create LEGACY_ENTITY datastream from Doc Archive contents <=2019
-    $legacy_ds = $object->constructDatastream('LEGACY_BIOGRAPHY_XML', 'M');
+    $legacy_ds = $object->constructDatastream('LEGACY_'.$main_ds_id, 'M');
     $legacy_ds->label = "legacy_" . $file_name;
     $legacy_ds->mimeType = 'text/xml';
     $legacy_ds->setContentFromString($legacy_content);
@@ -2529,6 +2529,26 @@ function drush_cwrc_migration_batch_ingest_orlando_entities()
             'stamp' => 'orlando:SUB',
             'status' => 'c',
             "note" => "Initial ingest into the CWRC repository.",
+            )
+          )
+        );
+      CWRCWorkflowAPI::updateDatastream($workflow, $object);
+
+      // update content datastream: UTF-8 and ISO 8601 dates
+      $object[$main_ds_id]->setContentFromString($clean_xml);
+
+      // add a workflow stamp indicating that the object was ingested
+      $workflow = CWRCWorkflowAPI::fromDatastream($object['WORKFLOW']);
+      $workflow->addWorkflowStep(
+        $object->id, 
+        new WorkflowItem(WorkflowConst::WORKFLOW, array()),
+        new WorkflowItem(
+          WorkflowConst::ACTIVITY,
+          array(
+            "category" => "machine_processed",
+            'stamp' => 'orlando:SUB',
+            'status' => 'c',
+            "note" => "UTF-8 and ISO 8601 dates.",
             )
           )
         );

--- a/includes/helpers.inc
+++ b/includes/helpers.inc
@@ -458,8 +458,9 @@ function add_entity_references(
         // update XML element node with new attribute
         if (!empty($attr_new) and !empty($pid))
         {
-          // writin the entity uri (base + PID)
-          $domElement->setAttribute($attr_new, $base_entity_url.$pid);
+          // write the entity uri (base + PID) + remove trailing forward slash and ensure one is added
+          $base_entity_url = rtrim($base_entity_url,'/');
+          $domElement->setAttribute($attr_new, $base_entity_url."/".$pid);
           drush_print("INFO: [$context] found with lookup [$lookup_str] for [$domElement->nodeValue] ref: [$pid]");
         }
         else

--- a/transforms/lib_orlando_date_helper.xsl
+++ b/transforms/lib_orlando_date_helper.xsl
@@ -191,7 +191,14 @@
         </xsl:if>
         
     </xsl:template>
-    
+
+    <!-- given a date in the legacy Orlando Doc Archive format (e.g., "2000- -" or "2000-10-") convert to iso6801 -->
+    <xsl:template name="legacy_orlando_date_to_iso">
+        <xsl:param name="INPUT_DATE"/>
+        <xsl:if test="$INPUT_DATE and string-length($INPUT_DATE) > 4">
+            <xsl:value-of select="replace(normalize-space($INPUT_DATE), '-{1,2}$','')"/>
+        </xsl:if>
+    </xsl:template>
     
     
     <!-- given a month, MM in 2 digit format, convert to the character representation -->

--- a/transforms/orlando_bibl_to_mods.xsl
+++ b/transforms/orlando_bibl_to_mods.xsl
@@ -408,7 +408,17 @@
     <xsl:template match="@PUBLISHED_AS_NAME" mode="bibliography">
         <displayForm><xsl:apply-templates select="." /></displayForm>
     </xsl:template>
-    
+
+    <!-- publisher template -->
+    <xsl:template match="PUBLISHER"> 
+        <xsl:element name="publisher">
+            <xsl:if test="ORGNAME/@REF">
+                <xsl:attribute name="valueURI" select="ORGNAME/@REF" />
+            </xsl:if>
+            <xsl:apply-templates select="ORGNAME" />
+        </xsl:element>
+    </xsl:template>
+
     <!-- originInfo template -->
     <xsl:template match="IMPRINT">
             <originInfo>
@@ -425,7 +435,7 @@
                 <!-- mpo: pending issue: express publisher as name type="corporate" with publisher role?
                     / if so, add to delivery metadata specs -->
                 <xsl:if test="PUBLISHER">
-                    <publisher><xsl:value-of select="PUBLISHER"/></publisher>
+                    <xsl:apply-templates select="PUBLISHER" />
                 </xsl:if>
                 <!-- dates -->
                 <xsl:apply-templates select="DATE_OF_PUBLICATION" mode="bibliography" />

--- a/transforms/orlando_bibl_to_mods.xsl
+++ b/transforms/orlando_bibl_to_mods.xsl
@@ -330,6 +330,9 @@
                     <xsl:attribute name="type">personal</xsl:attribute>
                 </xsl:otherwise>
             </xsl:choose>
+            <xsl:if test="NAME/@REF">
+                <xsl:attribute name="valueURI" select="NAME/@REF" />
+            </xsl:if>
             <!-- name variables -->
             <xsl:variable name="currentPositionNum" select="position()" />
             <xsl:variable name="lastPositionNum" select="last()" />

--- a/transforms/orlando_legacy_date_to_iso8601.xsl
+++ b/transforms/orlando_legacy_date_to_iso8601.xsl
@@ -1,15 +1,12 @@
-
 <!--
-* convert Orlando Legacy Biography and Writing documents, bibl, and entities into a CWRC v2 format
-** remove named character references (e.g., &eacute; etc.) - XSL does this automatically
-** remove the Orlando Legacy data format 2016-01- or double  '-' if no month
-
+* convert Orlando Legacy date format to ISO 8601 in MODS records
 -->
 
 <xsl:stylesheet
     version="2.0"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:tei="http://www.tei-c.org/ns/1.0"
+    xmlns:mods="http://www.loc.gov/mods/v3" exclude-result-prefixes="mods"
     >
     
     <xsl:output method="xml" encoding="UTF-8"/>
@@ -29,8 +26,7 @@
             <xsl:apply-templates select="child::node()"/>
         </xsl:copy>
     </xsl:template>
-    
-    
+
     <!--
     * add all attributes
     -->
@@ -43,17 +39,15 @@
       * update date attributes:
       * convert from legacy Orlando format to ISO8601 (e.g. YYYY-MM- to YYYY-MM)
     -->
-    <xsl:template match="DATE/@VALUE | DATESTRUCT/@VALUE | DATERANGE/@FROM | DATERANGE/@TO | DATE_OF_PUBLICATION/@REG | DATE_OF_ORIGINAL_PUBLICATION/@REG | DATE_OF_ACCESS/@REG" >
+    <xsl:template match="mods:dateOther | mods:dateIssued | mods:dateCreated">
         <!-- trim Orlando format date -->
-        <xsl:attribute name='{name(.)}'>
+        <xsl:element name='{name(.)}' namespace="http://www.loc.gov/mods/v3">
+            <xsl:apply-templates select="@*" />
             <xsl:call-template name="legacy_orlando_date_to_iso">
-                <xsl:with-param name="INPUT_DATE" select="."/>
+                <xsl:with-param name="INPUT_DATE" select="text()"/>
             </xsl:call-template>
-        </xsl:attribute>
+        </xsl:element>
 
     </xsl:template>
-    
-    
+
 </xsl:stylesheet>
-
-

--- a/xml/default_XACML_Policy_Stream.xml
+++ b/xml/default_XACML_Policy_Stream.xml
@@ -1,161 +1,161 @@
-
+<?xml version="1.0" encoding="UTF-8"?>
 <Policy xmlns="urn:oasis:names:tc:xacml:1.0:policy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PolicyId="islandora-xacml-editor-v1" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable">
   <Target>
     <Subjects>
-      <AnySubject></AnySubject>
+      <AnySubject/>
     </Subjects>
     <Resources>
-      <AnyResource></AnyResource>
+      <AnyResource/>
     </Resources>
     <Actions>
-      <AnyAction></AnyAction>
+      <AnyAction/>
     </Actions>
   </Target>
-  <Rule Effect="Deny" RuleId="deny-management-functions">
+  <Rule RuleId="deny-management-functions" Effect="Deny">
     <Target>
       <Subjects>
-        <AnySubject></AnySubject>
+        <AnySubject/>
       </Subjects>
       <Resources>
-        <AnyResource></AnyResource>
+        <AnyResource/>
       </Resources>
       <Actions>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-addDatastream</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-addDisseminator</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-adminPing</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-getDisseminatorHistory</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-getNextPid</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-ingest</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-modifyDatastreamByReference</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-modifyDatastreamByValue</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>  
-        </ActionMatch>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
+          </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-modifyDisseminator</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-modifyObject</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-purgeObject</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-purgeDatastream</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-purgeDisseminator</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-setDatastreamState</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-setDisseminatorState</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-setDatastreamVersionable</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-compareDatastreamChecksum</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-serverShutdown</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-serverStatus</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-upload</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-dsstate</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-resolveDatastream</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-reloadPolicies</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
       </Actions>
@@ -163,47 +163,51 @@
     <Condition FunctionId="urn:oasis:names:tc:xacml:1.0:function:not">
       <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:or">
         <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-at-least-one-member-of">
-          <SubjectAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:subject:loginId" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"></SubjectAttributeDesignator>
+          <SubjectAttributeDesignator DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" AttributeId="urn:fedora:names:fedora:2.1:subject:loginId"/>
           <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-bag">
-            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">admin</AttributeValue>
+            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">adminUP</AttributeValue>
+            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ilovan</AttributeValue>
+            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">jefferya</AttributeValue>
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">fedoraAdmin</AttributeValue>
           </Apply>
         </Apply>
         <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-at-least-one-member-of">
-          <SubjectAttributeDesignator AttributeId="fedoraRole" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"></SubjectAttributeDesignator>
+          <SubjectAttributeDesignator DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" AttributeId="fedoraRole"/>
           <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-bag">
-            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Orlando user</AttributeValue>
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">administrator</AttributeValue>
+            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">node:42:2:member</AttributeValue>
+            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">node:42:4:project contributor</AttributeValue>
+            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">node:42:5:project editor</AttributeValue>
           </Apply>
         </Apply>
       </Apply>
     </Condition>
   </Rule>
-  <Rule Effect="Deny" RuleId="deny-access-functions">
+  <Rule RuleId="deny-access-functions" Effect="Deny">
     <Target>
       <Subjects>
-        <AnySubject></AnySubject>
+        <AnySubject/>
       </Subjects>
       <Resources>
-        <AnyResource></AnyResource>
+        <AnyResource/>
       </Resources>
       <Actions>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:api-a</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:api" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:api" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-getDatastreamHistory</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
         <Action>
           <ActionMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">urn:fedora:names:fedora:2.1:action:id-listObjectInResourceIndexResults</AttributeValue>
-            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"></ActionAttributeDesignator>
+            <ActionAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:action:id" DataType="http://www.w3.org/2001/XMLSchema#string"/>
           </ActionMatch>
         </Action>
       </Actions>
@@ -211,32 +215,36 @@
     <Condition FunctionId="urn:oasis:names:tc:xacml:1.0:function:not">
       <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:or">
         <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-at-least-one-member-of">
-          <SubjectAttributeDesignator AttributeId="urn:fedora:names:fedora:2.1:subject:loginId" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"></SubjectAttributeDesignator>
+          <SubjectAttributeDesignator DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" AttributeId="urn:fedora:names:fedora:2.1:subject:loginId"/>
           <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-bag">
-            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">admin</AttributeValue>
+            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">adminUP</AttributeValue>
+            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">ilovan</AttributeValue>
+            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">jefferya</AttributeValue>
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">fedoraAdmin</AttributeValue>
           </Apply>
         </Apply>
         <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-at-least-one-member-of">
-          <SubjectAttributeDesignator AttributeId="fedoraRole" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false"></SubjectAttributeDesignator>
+          <SubjectAttributeDesignator DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" AttributeId="fedoraRole"/>
           <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-bag">
-            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Orlando user</AttributeValue>
             <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">administrator</AttributeValue>
+            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">node:42:2:member</AttributeValue>
+            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">node:42:4:project contributor</AttributeValue>
+            <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">node:42:5:project editor</AttributeValue>
           </Apply>
         </Apply>
       </Apply>
     </Condition>
   </Rule>
-  <Rule Effect="Permit" RuleId="allow-everything-else">
+  <Rule RuleId="allow-everything-else" Effect="Permit">
     <Target>
       <Subjects>
-        <AnySubject></AnySubject>
+        <AnySubject/>
       </Subjects>
       <Resources>
-        <AnyResource></AnyResource>
+        <AnyResource/>
       </Resources>
       <Actions>
-        <AnyAction></AnyAction>
+        <AnyAction/>
       </Actions>
     </Target>
   </Rule>


### PR DESCRIPTION
Addresses:
* Orlando entries to use legacy id as part of the PID: https://github.com/cwrc/OrlandoMigration-TestOutputs/issues/15
* Person/Org/bibliographic content: add legacy datastream reflecting the legacy format: https://github.com/cwrc/OrlandoMigration-TestOutputs/issues/13
* Updates content of the policy datastream
* Converts Orlando legacy date format in bibliographic material to the ISO 8601 format: https://github.com/cwrc/OrlandoMigration-TestOutputs/issues/17
* Fixes a missing forward slash in the URIs added to entities: https://github.com/cwrc/OrlandoMigration-TestOutputs/issues/16
* Add URIs to author and publisher (where possible): https://github.com/cwrc/OrlandoMigration-TestOutputs/issues/18